### PR TITLE
Get Bridgetown loading inside a parent Roda app

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -3,13 +3,19 @@
 require 'bundler/setup'
 require 'puma'
 require 'roda'
-require 'bridgetown-core'
-require 'bridgetown-core/rack/boot'
 require 'bridgetown'
 require_relative 'app/api'
-require_relative 'docs/server/roda_app'
 
-Bridgetown::Rack.boot
+# Set config object up before requiring Bridgetown Rack boot
+Bridgetown::Current.preloaded_configuration = Bridgetown.configuration(
+  root_dir: File.expand_path("docs", __dir__),
+  source: File.expand_path("docs/src", __dir__),
+  destination: File.expand_path("docs/output", __dir__),
+  base_path: "/" # we need to reset this from /docs to / because of the RodaApp mount point below
+)
+
+require 'bridgetown-core/rack/boot'
+Bridgetown::Rack.boot # this will automatically load ./docs/server/*.rb
 
 class App < Roda
   route do |r|

--- a/docs/bin/bt
+++ b/docs/bin/bt
@@ -9,7 +9,7 @@
 #
 
 require 'pathname'
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile',
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile',
                                            Pathname.new(__FILE__).realpath)
 
 bundle_binstub = File.expand_path('bundle', __dir__)

--- a/docs/bridgetown.config.yml
+++ b/docs/bridgetown.config.yml
@@ -24,7 +24,7 @@ template_engine: liquid
 
 # Other options you might want to investigate:
 #
-# base_path: "/" # the subpath of your site, e.g. /blog. If you set this option,
+base_path: "/docs" # the subpath of your site, e.g. /blog. If you set this option,
 # ensure you use the `relative_url` helper for all links and assets in your HTML.
 # If you're using esbuild for frontend assets, edit `esbuild.config.js` to
 # update `publicPath`.


### PR DESCRIPTION
I was able to get it working by setting up a preloaded configuration object within the parent Roda app and a couple of other tweaks.